### PR TITLE
Merge fix mismatched sample index

### DIFF
--- a/cirrus-lib/crates/client/src/audio_player/player.rs
+++ b/cirrus-lib/crates/client/src/audio_player/player.rs
@@ -415,33 +415,18 @@ impl AudioStreamInner {
         self.audio_player_status.store(PlaybackStatus::Pause as usize, Ordering::Relaxed);
         self.set_stream_playback(PlaybackStatus::Pause)?;
 
-        let get_remain_buffer_len_as_source = || {
-            (
-                self.audio_sample.get_remain_sample_buffer_len() as f32 * (
-                    self.audio_sample.resampler_frames_input_next as f32 / self.audio_sample.resampler_frames_output_next as f32
-                )
-            ).floor() as usize
-        };
-
         let position_sample_idx = self.audio_sample.get_sample_idx_from_sec(position_sec);
         let drain_buffer_len = {
             if position_sec - self.audio_sample.get_current_playback_position_sec() > 0.0 {
                 position_sample_idx - self.audio_sample.get_current_sample_idx()
             } else {
                 self.audio_sample.get_remain_sample_buffer_len()
-                // usize::MAX
             }
         };
 
         self.audio_sample.drain_sample_buffer(drain_buffer_len);
-
-        let source_sample_req_pos = 
-            (position_sec * self.audio_sample.source.metadata.sample_rate as f32).floor() as usize + 
-            get_remain_buffer_len_as_source();
-        self.audio_sample.last_buf_req_pos.store(source_sample_req_pos, Ordering::SeqCst);
         self.audio_sample.set_current_sample_frame_idx(position_sample_idx);
 
-        // self.audio_sample.buffer_status.store(AudioSampleStatus::Play as usize, Ordering::SeqCst);
         self.audio_player_status.store(PlaybackStatus::Play as usize, Ordering::Relaxed);
         self.set_stream_playback(PlaybackStatus::Play)?;
 

--- a/cirrus-lib/crates/client/src/audio_player/sample.rs
+++ b/cirrus-lib/crates/client/src/audio_player/sample.rs
@@ -17,7 +17,6 @@ pub struct AudioSample {
     sample_buffer: Arc<RwLock<Vec<VecDeque<f32>>>>,
     current_sample_frame: Arc<AtomicUsize>,
     pub buffer_status: Arc<AtomicUsize>,
-    pub last_buf_req_pos: Arc<AtomicUsize>,
     resampler: Arc<RwLock<rubato::FftFixedInOut<f32>>>,
     pub resampler_frames_input_next: usize,
     pub resampler_frames_output_next: usize,
@@ -54,7 +53,6 @@ impl AudioSample {
             sample_buffer: Arc::new(RwLock::new(sample_buffer)),
             current_sample_frame: Arc::new(AtomicUsize::new(0)),
             buffer_status: Arc::new(AtomicUsize::new(AudioSampleStatus::FillBuffer as usize)),
-            last_buf_req_pos: Arc::new(AtomicUsize::new(0)),
             resampler: Arc::new(
                 RwLock::new(
                     resampler
@@ -63,7 +61,6 @@ impl AudioSample {
             resampler_frames_input_next,
             resampler_frames_output_next,
             remain_sample_raw: Arc::new(RwLock::new(Vec::new())),
-            // resampled_sample_frames,
             host_sample_rate,
             host_output_channels,
             content_length,
@@ -139,13 +136,15 @@ impl AudioSample {
     pub async fn get_buffer_for(&self, ms: u32) -> Result<usize, anyhow::Error> {
         let req_samples = ms * self.source.metadata.sample_rate / 1000;
         
-        // println!("request audio data part");
-        let last_buf_req_pos = self.last_buf_req_pos.load(Ordering::SeqCst);
+        let buf_req_pos = (
+            (self.get_current_playback_position_sec() + self.get_remain_sample_buffer_sec()) * 
+                self.source.metadata.sample_rate as f32
+        ).floor() as usize;
 
         let sample_res = request::get_audio_data(
             &self.source.id,
-            std::cmp::min(last_buf_req_pos as u32, self.source.metadata.sample_frames as u32),
-            std::cmp::min(last_buf_req_pos as u32 + req_samples, self.source.metadata.sample_frames as u32)
+            std::cmp::min(buf_req_pos as u32, self.source.metadata.sample_frames as u32),
+            std::cmp::min(buf_req_pos as u32 + req_samples, self.source.metadata.sample_frames as u32)
         ).await?;
 
         // println!("parse audio data response as audio sample");
@@ -186,8 +185,6 @@ impl AudioSample {
             if  AudioSampleStatus::StopFillBuffer == AudioSampleStatus::from(self.buffer_status.load(Ordering::Relaxed)) {
                 println!("stop fill buffer");
 
-                self.last_buf_req_pos.store(last_buf_req_pos + channel_sample_buf_extend_cnt, Ordering::SeqCst);
-
                 return Ok(channel_sample_buf_extend_cnt);
             }
 
@@ -202,8 +199,6 @@ impl AudioSample {
         let remain_samples = chunks_items_iter.remainder();
         remain_sample_raw.extend(remain_samples);
 
-        // println!("done resampling wave data");
-        self.last_buf_req_pos.store(last_buf_req_pos + req_samples as usize, Ordering::SeqCst);
         
         Ok(channel_sample_buf_extend_cnt)
     }


### PR DESCRIPTION
# Fixes
* The position of the audio sample retrieved after rewind of the audio does not match the playback position.